### PR TITLE
Show 'right arrow' for collapse/expand menu item when sidebar collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -140,4 +140,8 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  &.sidebarCollapsed img {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -78,11 +78,14 @@ export function SidebarNavigation() {
               onClick={() => alert("Support")}
             />
             <MenuItemButton
-              text="Collapse"
+              text={isSidebarCollapsed ? "Expand" : "Collapse"}
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.sidebarCollapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Also change the 'Collapse' alt text to 'Expand' when sidebar is collapsed